### PR TITLE
setup.py cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,37 +43,37 @@ else:
     sys.exit(1)
 
 setup(
-	name = 'leveldb',
-	version = '0.193',
-	maintainer = 'Arni Mar Jonsson',
-	maintainer_email = 'arnimarkj@gmail.com',
-	url = 'https://code.google.com/p/py-leveldb/',
+    name = 'leveldb',
+    version = '0.193',
+    maintainer = 'Arni Mar Jonsson',
+    maintainer_email = 'arnimarkj@gmail.com',
+    url = 'https://code.google.com/p/py-leveldb/',
 
-	classifiers = [
-		'Development Status :: 4 - Beta',
-		'Environment :: Other Environment',
-		'Intended Audience :: Developers',
-		'License :: OSI Approved :: BSD License',
-		'Operating System :: POSIX',
-		'Programming Language :: C++',
-		'Programming Language :: Python',
-		'Programming Language :: Python :: 2.4',
-		'Programming Language :: Python :: 2.5',
-		'Programming Language :: Python :: 2.6',
-		'Programming Language :: Python :: 2.7',
-		'Programming Language :: Python :: 3.0',
-		'Programming Language :: Python :: 3.1',
-		'Programming Language :: Python :: 3.2',
-		'Programming Language :: Python :: 3.3',
-		'Topic :: Database',
-		'Topic :: Software Development :: Libraries'
-	],
+    classifiers = [
+        'Development Status :: 4 - Beta',
+        'Environment :: Other Environment',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: POSIX',
+        'Programming Language :: C++',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.4',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.0',
+        'Programming Language :: Python :: 3.1',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Topic :: Database',
+        'Topic :: Software Development :: Libraries'
+    ],
 
-	description = 'Python bindings for leveldb database library',
+    description = 'Python bindings for leveldb database library',
 
-	ext_modules = [
-		Extension('leveldb',
-			sources = [
+    ext_modules = [
+        Extension('leveldb',
+            sources = [
                 # snappy
                 './snappy/snappy.cc',
                 './snappy/snappy-stubs-internal.cc',
@@ -123,9 +123,9 @@ setup(
                 # python stuff
                 'leveldb_ext.cc',
                 'leveldb_object.cc',
-		    ],
-			libraries = ['stdc++'],
-			extra_compile_args = extra_compile_args,
-		)
-	]
+            ],
+            libraries = ['stdc++'],
+            extra_compile_args = extra_compile_args,
+        )
+    ]
 )


### PR DESCRIPTION
Hi there, 
Here are some setup.py fixes:
- use syntax that is supported by both Python 3 and Python 2;
- respect virtualenv in shebang;
- remove unneeded import;
- fix 2-space, 1-tab and inconsistent indentation;
- use https URL for the repo link.
