### PR TITLE
Fix method descriptors for Python 3.8

### DIFF
--- a/leveldb_object.cc
+++ b/leveldb_object.cc
@@ -763,7 +763,7 @@ static PyMethodDef PyLevelDB_methods[] = {
 	{(char*)"Delete",         (PyCFunction)PyLevelDB_Delete,    METH_VARARGS | METH_KEYWORDS, (char*)"delete a value in the database" },
 	{(char*)"Write",          (PyCFunction)PyLevelDB_Write,     METH_VARARGS | METH_KEYWORDS, (char*)"apply a write-batch"},
 	{(char*)"RangeIter",      (PyCFunction)PyLevelDB_RangeIter, METH_VARARGS | METH_KEYWORDS, (char*)"key/value range scan"},
-	{(char*)"GetStats",       (PyCFunction)PyLevelDB_GetStatus, METH_VARARGS | METH_NOARGS,   (char*)"get a mapping of all DB statistics"},
+	{(char*)"GetStats",       (PyCFunction)PyLevelDB_GetStatus, METH_NOARGS,   (char*)"get a mapping of all DB statistics"},
 	{(char*)"CreateSnapshot", (PyCFunction)PyLevelDB_CreateSnapshot, METH_NOARGS, (char*)"create a new snapshot from current DB state"},
 	{(char*)"CompactRange", (PyCFunction)PyLevelDB_CompactRange, METH_VARARGS | METH_KEYWORDS, (char*)"Compact keys in the range"},
 	{NULL}


### PR DESCRIPTION
Importing leveldb in Python 3.8 raises `SystemError: bad call flags`.
This is due to a change in Python where the method descriptor flags are
checked at import time, rather than when the methods are called.  This
change fixes the incorrect method description.

Adapted from @vstinner's fix for the same problem in libcomps.

https://github.com/rpm-software-management/libcomps/pull/50