### PR TITLE
Remove use of deprecated API

### DIFF
--- a/leveldb_object.cc
+++ b/leveldb_object.cc
@@ -785,19 +785,13 @@ static int pyleveldb_str_eq(PyObject* p, const char* s)
 {
 	// 8-bit string
 	#if PY_MAJOR_VERSION < 3
-	if (PyString_Check(p) && strcmp(PyString_AS_STRING(p), "bytewise") == 0)
+	if (PyString_Check(p) && strcmp(PyString_AS_STRING(p), s) == 0)
 		return 1;
 	#endif
 
 	// unicode string
 	if (PyUnicode_Check(p)) {
-		size_t i = 0;
-		Py_UNICODE* c = PyUnicode_AS_UNICODE(p);
-
-		while (s[i] && c[i] && (int)s[i] == (int)c[i])
-			i++;
-
-		return ((int)s[i] == (int)c[i]);
+		return PyUnicode_CompareWithASCIIString(p, s) == 0;
 	}
 
 	return 0;


### PR DESCRIPTION
PyUnicode_AS_UNICODE is deprecated and slow since 3.3.