### PR TITLE
Update URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     version = '0.20',
     maintainer = 'Arni Mar Jonsson',
     maintainer_email = 'arnimarkj@gmail.com',
-    url = 'https://code.google.com/p/py-leveldb/',
+    url = 'https://github.com/rjpower/py-leveldb.git',
 
     classifiers = [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
The code.google.com URL no longer appears to exist. I assume this is the new authoritative project location